### PR TITLE
Update freedesktop.Platform to 24.08, Java to 21, remove xrandr

### DIFF
--- a/io.github.yairm210.unciv.yaml
+++ b/io.github.yairm210.unciv.yaml
@@ -1,8 +1,8 @@
 app-id: io.github.yairm210.unciv
 runtime: org.freedesktop.Platform
-runtime-version: '23.08'
+runtime-version: '24.08'
 sdk: org.freedesktop.Sdk
-sdk-extensions: [org.freedesktop.Sdk.Extension.openjdk17]
+sdk-extensions: [org.freedesktop.Sdk.Extension.openjdk21]
 command: unciv
 finish-args:
   - --socket=x11
@@ -15,13 +15,7 @@ finish-args:
 modules:
   - name: openjdk
     buildsystem: simple
-    build-commands: [/usr/lib/sdk/openjdk17/install.sh]
-
-  - name: xrandr
-    sources:
-      - type: archive
-        url: https://xorg.freedesktop.org/archive/individual/app/xrandr-1.5.1.tar.xz
-        sha256: 7bc76daf9d72f8aff885efad04ce06b90488a1a169d118dea8a2b661832e8762
+    build-commands: [/usr/lib/sdk/openjdk21/install.sh]
 
   - name: unciv
     buildsystem: simple


### PR DESCRIPTION
xrandr is necessary for running Unciv on wayland, but libxrandr from the runtime seems to be sufficient